### PR TITLE
Fix a crash on save-load (related to Holograph)

### DIFF
--- a/include/libdev/machlog/oreholo.hpp
+++ b/include/libdev/machlog/oreholo.hpp
@@ -57,6 +57,8 @@ public:
 	
 	friend class MachLogMineralSite;
 
+	void assignToDifferentRace( MachLogRace& newRace );
+
 protected:
 	virtual void doStartExplodingAnimation();
 	virtual void doEndExplodingAnimation();

--- a/src/libdev/machlog/oreholo.cpp
+++ b/src/libdev/machlog/oreholo.cpp
@@ -136,6 +136,16 @@ const MachLogMineralSite& MachLogOreHolograph::mineralSite() const
 	return *pRetVal;
 }
 
+void MachLogOreHolograph::assignToDifferentRace(MachLogRace &newRace)
+{
+	// OreHolograph race change does not work:
+	// Save files do not have Holographes but only MineralSites
+	// During the load MineralSites create Holographes for the 'Race discoveredBy_'
+
+	// See void perRead( PerIstream& istr, MachLogMineralSiteImpl& siteImpl ) in minesiti.cpp:64 for details
+	return;
+}
+
 void MachLogOreHolograph::removeMe()
 {
 	isDead( true );

--- a/src/libdev/machlog/persist.cpp
+++ b/src/libdev/machlog/persist.cpp
@@ -126,7 +126,11 @@ void MachLogPersistence::setDataForWrite() const
 	{
 		if( MachLogRaces::instance().raceObjects( i ).size() > 0 )
 		{
-			nonConstPer.controllers_.push_back( &MachLogRaces::instance().controller( i ) );
+			MachLogController *pController = &MachLogRaces::instance().controller( i );
+			if ( !pController )
+				continue;
+
+			nonConstPer.controllers_.push_back( pController );
 		}
 	}
 }


### PR DESCRIPTION
Steps to reproduce the crash:
1. Start the first mission ("Make Contact")
2. Get the commander
3. Get the base (scripted `ChangeRaceAction` change the Holo race from GREEN to RED)
4. Save the game (GREEN controller is not saved because the race has no objects)
5. Load that save file (Holo re-created for GREEN but there is no controller)
6. Save the game (the current code happily writes garbage from `pController=nullptr`)
7. Load that new save file (crash on trying to recreate the stuff according to the garbage)